### PR TITLE
add Django 3.2 support (fixes #126)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
   - DJANGO_VERSION=1.11
   - DJANGO_VERSION=2.2
   - DJANGO_VERSION=3.0
+  - DJANGO_VERSION=3.2
 
 jobs:
   exclude:
@@ -31,6 +32,10 @@ jobs:
       env: DJANGO_VERSION=3.0
     - python: 3.5
       env: DJANGO_VERSION=3.0
+    - python: 2.7
+      env: DJANGO_VERSION=3.2
+    - python: 3.5
+      env: DJANGO_VERSION=3.2
     - python: 3.8
       env: DJANGO_VERSION=1.8
     - python: 3.8
@@ -39,7 +44,6 @@ jobs:
       env: DJANGO_VERSION=1.10
     - python: 3.8
       env: DJANGO_VERSION=1.11
-
 
 install:
   - pip install coveralls flake8 urllib3

--- a/revproxy/response.py
+++ b/revproxy/response.py
@@ -45,8 +45,6 @@ def get_django_response(proxy_response, strict_cookies=False):
     logger.info('Normalizing response headers')
     set_response_headers(response, headers)
 
-    logger.debug('Response headers: %s', getattr(response, '_headers'))
-
     cookies = proxy_response.headers.getlist('set-cookie')
     logger.info('Checking for invalid cookies')
     for cookie_string in cookies:

--- a/revproxy/utils.py
+++ b/revproxy/utils.py
@@ -117,14 +117,24 @@ def required_header(header):
 
 
 def set_response_headers(response, response_headers):
+    # check for Django 3.2 headers interface
+    # https://code.djangoproject.com/ticket/31789
+    # check and set pointer before loop to improve efficiency
+    if hasattr(response, 'headers'):
+        headers = response.headers
+    else:
+        headers = response
 
     for header, value in response_headers.items():
         if is_hop_by_hop(header) or header.lower() == 'set-cookie':
             continue
 
-        response[header.title()] = value
+        headers[header] = value
 
-    logger.debug('Response headers: %s', getattr(response, '_headers'))
+    if hasattr(response, 'headers'):
+        logger.debug('Response headers: %s', response.headers)
+    else:
+        logger.debug('Response headers: %s', getattr(response, '_headers'))
 
 
 def normalize_request_headers(request):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -78,7 +78,11 @@ class ResponseTest(TestCase):
         with patch(URLOPEN, urlopen_mock):
             response = CustomProxyView.as_view()(request, path)
 
-        response_headers = response._headers
+        # Django 3.2+
+        if hasattr(response, 'headers'):
+            response_headers = response.headers
+        else:
+            response_headers = response._headers
 
         for header in response_headers:
             self.assertFalse(is_hop_by_hop(header))
@@ -122,7 +126,11 @@ class ResponseTest(TestCase):
         with patch(URLOPEN, urlopen_mock):
             response = CustomProxyView.as_view()(request, path)
 
-        response_headers = response._headers
+        # Django 3.2+
+        if hasattr(response, 'headers'):
+            response_headers = response.headers
+        else:
+            response_headers = response._headers
         self.assertNotIn('set-cookie', response_headers)
 
     def test_set_cookie_is_used_by_httpproxy_response(self):
@@ -157,5 +165,9 @@ class ResponseTest(TestCase):
         with patch(URLOPEN, urlopen_mock):
             response = CustomProxyView.as_view()(request, path)
 
-        response_headers = response._headers
+        # Django 3.2+
+        if hasattr(response, 'headers'):
+            response_headers = response.headers
+        else:
+            response_headers = response._headers
         self.assertFalse(response.cookies)


### PR DESCRIPTION
PR on upstream, that isn't getting merged

https://github.com/TracyWebTech/django-revproxy/issues/126

* check for `response.headers` attribute, fallback to old interface if missing
* updated tests to expect Django 3.2+ response.headers
* added Django 3.2 in .travis.yml

